### PR TITLE
Restart on start instead of trying to continue

### DIFF
--- a/src/handler/abort.rs
+++ b/src/handler/abort.rs
@@ -51,7 +51,7 @@ mod test {
         let services = Mutex::new(get_empty_backend());
 
         let prefix = PathPrefix::new();
-        let mut transfer = Transfer::new(&prefix);
+        let mut transfer = Transfer::new_test(&prefix);
         let package = transfer.randomize(10);
 
         let transfers = Mutex::new(HashMap::new());
@@ -70,7 +70,7 @@ mod test {
         let services = Mutex::new(get_empty_backend());
 
         let prefix = PathPrefix::new();
-        let mut transfer = Transfer::new(&prefix);
+        let mut transfer = Transfer::new_test(&prefix);
         let package = transfer.randomize(10);
 
         let transfers = Mutex::new(HashMap::new());

--- a/src/handler/chunk.rs
+++ b/src/handler/chunk.rs
@@ -96,7 +96,7 @@ mod test {
         test_init!();
         for i in 1..20 {
             let prefix = PathPrefix::new();
-            let mut transfer = Transfer::new(&prefix);
+            let mut transfer = Transfer::new_test(&prefix);
             let package = transfer.randomize(i);
             let transfers = Mutex::new(HashMap::new());
             transfers.lock().unwrap().insert(package.clone(), transfer);

--- a/src/handler/finish.rs
+++ b/src/handler/finish.rs
@@ -73,7 +73,7 @@ mod test {
         test_init!();
         for i in 1..20 {
             let prefix = PathPrefix::new();
-            let mut transfer = Transfer::new(&prefix);
+            let mut transfer = Transfer::new_test(&prefix);
             transfer.checksum =
                 "4e1243bd22c66e76c2ba9eddc1f91394e57f9f83".to_string();
             let package = transfer.randomize(i);
@@ -92,7 +92,7 @@ mod test {
         test_init!();
         for i in 1..20 {
             let prefix = PathPrefix::new();
-            let mut transfer = Transfer::new(&prefix);
+            let mut transfer = Transfer::new_test(&prefix);
             transfer.checksum =
                 "4e1243bd22c66e76c2ba9eddc1f91394e57f9f83".to_string();
             let package = transfer.randomize(i);
@@ -125,7 +125,7 @@ mod test {
         test_init!();
         for i in 1..20 {
             let prefix = PathPrefix::new();
-            let mut transfer = Transfer::new(&prefix);
+            let mut transfer = Transfer::new_test(&prefix);
             transfer.checksum =
                 "4e1243bd22c66e76c2ba9eddc1f91394e57f9f83".to_string();
             let package = transfer.randomize(i);

--- a/src/handler/start.rs
+++ b/src/handler/start.rs
@@ -23,10 +23,9 @@ impl HandleMessageParams for StartParams {
 
         info!("Starting transfer for package {}", self.package);
 
-        let transfer =
-            Transfer::from_disk(self.package.clone(),
-                                self.checksum.clone(),
-                                storage_dir.to_string());
+        let transfer = Transfer::new(storage_dir.to_string(),
+                                     self.package.clone(),
+                                     self.checksum.clone());
 
         let chunk_received = ChunkReceived {
             package: self.package.clone(),


### PR DESCRIPTION
As per DEV-58 a transfer should be restarted instead of continued, if a
subsequent start message is received. Because of that the possibility of
loading transfers from disk is removed.