### PR TITLE
Make VIN detection configurable

### DIFF
--- a/client.toml
+++ b/client.toml
@@ -3,6 +3,7 @@ storage_dir = "/var/sota"
 rvi_url = "http://127.0.0.1:8901"
 edge_url = "127.0.0.1:9080"
 timeout = 20
+vin_match = 2
 
 [dbus]
 name = "org.genivi.sota_client"

--- a/src/configuration/configuration.rs
+++ b/src/configuration/configuration.rs
@@ -8,6 +8,7 @@ use super::common::{ConfTreeParser, format_parser_error, stringify, Result};
 use super::client::ClientConfiguration;
 use super::dbus::DBusConfiguration;
 
+#[derive(Clone)]
 pub struct Configuration {
     pub client: ClientConfiguration,
     pub dbus: DBusConfiguration

--- a/src/message/initiate.rs
+++ b/src/message/initiate.rs
@@ -35,9 +35,8 @@ impl LocalServices {
         services
     }
 
-    pub fn get_vin(&self) -> String {
-        // TODO: rather match by regex, than on a specific url part
-        self.start.split("/").nth(2).unwrap().to_string()
+    pub fn get_vin(&self, vin_match: i32) -> String {
+        self.start.split("/").nth(vin_match as usize).unwrap().to_string()
     }
 }
 
@@ -49,14 +48,12 @@ pub struct InitiateParams {
 }
 
 impl InitiateParams {
-    pub fn new(p: PackageId,
-               s: LocalServices) -> InitiateParams {
-        let vin = s.get_vin();
-
+    pub fn new(p: PackageId, s: LocalServices,
+               v: String) -> InitiateParams {
         InitiateParams {
             packages: vec!(p),
             services: s,
-            vin: vin
+            vin: v
         }
     }
 }


### PR DESCRIPTION
The VIN detection used to look at a hard coded part of the registration
URL we get back from RVI. Now the user can configure which part of the
registration URL string contains the VIN, or any other identifier, that
is sent to the server as callback address.