### PR TITLE
Simplify main_loop

### DIFF
--- a/src/handler/report.rs
+++ b/src/handler/report.rs
@@ -17,6 +17,6 @@ impl HandleMessageParams for ReportParams {
     }
 
     fn get_message(&self) -> Option<Notification> {
-        Some(Notification::RequestReport)
+        Some(Notification::Report)
     }
 }

--- a/src/message/client.rs
+++ b/src/message/client.rs
@@ -6,10 +6,8 @@ use super::server::BackendServices;
 pub enum Notification {
     Notify(UserMessage),
     Initiate(PackageId),
-    InstallReport(PackageReport),
-    Report(Vec<PackageId>),
+    Report,
     Finish(PackageId),
-    RequestReport
 }
 
 #[derive(RustcDecodable, Clone, PartialEq, Eq, Debug)]

--- a/src/sota_dbus/mod.rs
+++ b/src/sota_dbus/mod.rs
@@ -1,6 +1,5 @@
 mod sender;
 mod receiver;
 
-pub use self::sender::Sender;
-pub use self::sender::Request;
+pub use self::sender::{send_notify, request_install, request_report};
 pub use self::receiver::Receiver;

--- a/src/sota_dbus/sender.rs
+++ b/src/sota_dbus/sender.rs
@@ -1,106 +1,62 @@
-use std::sync::mpsc;
 use std::convert::From;
 use std::borrow::Cow;
 
 use dbus::{Connection, BusType, MessageItem, Message, FromMessageItem};
 
 use configuration::DBusConfiguration;
-use message::{UserPackage, PackageId, PackageReport, Notification};
+use message::{UserPackage, PackageId, PackageReport};
 use message::ParsePackageReport;
 
-pub enum Request {
-    Notify(Vec<UserPackage>),
-    Complete(PackageId),
-    Report
+pub fn send_notify(config: &DBusConfiguration, packages: Vec<UserPackage>) {
+    let connection = Connection::get_private(BusType::Session).unwrap();
+    let mut message =
+        Message::new_method_call(&config.software_manager, "/",
+                                 &config.software_manager, "Notify")
+        .unwrap();
+
+    let mut message_items = Vec::new();
+    for package in packages {
+        message_items.push(MessageItem::from(package));
+    }
+
+    // hardcoded signature as a workaround for diwic/dbus-rs#24
+    // needs to stay in until the fix is released and works on stable
+    let args = [MessageItem::Array(message_items,
+                                   Cow::Owned("(a{ss}t)".to_string()))];
+
+    message.append_items(&args);
+    if connection.send(message).is_err() {
+        error!("Couldn't forward message to D-Bus");
+    }
 }
 
-pub struct Sender {
-    config: DBusConfiguration,
-    receiver: mpsc::Receiver<Request>,
-    sender: mpsc::Sender<Notification>
-}
-
-impl Sender {
-    pub fn new(c: DBusConfiguration,
-               r: mpsc::Receiver<Request>,
-               s: mpsc::Sender<Notification>) -> Sender {
-        Sender {
-            config: c,
-            receiver: r,
-            sender: s
-        }
-    }
-
-    pub fn start(&self) {
-        loop {
-            match self.receiver.recv().unwrap() {
-                Request::Notify(packages) => {
-                    self.send_notify(packages);
-                },
-                Request::Complete(package) => {
-                    let result = self.send_complete(package);
-                    let report = Notification::InstallReport(result);
-                    let _ = self.sender.send(report);
-                },
-                Request::Report => {
-                    let result = self.request_report();
-                    let report = Notification::Report(result);
-                    let _ = self.sender.send(report);
-                }
-            }
-        }
-    }
-
-    fn send_notify(&self, packages: Vec<UserPackage>) {
+pub fn request_install(config: &DBusConfiguration, package: PackageId)
+    -> PackageReport {
         let connection = Connection::get_private(BusType::Session).unwrap();
         let mut message =
-            Message::new_method_call(&self.config.software_manager, "/",
-                                     &self.config.software_manager, "Notify")
-            .unwrap();
-
-        let mut message_items = Vec::new();
-        for package in packages {
-            message_items.push(MessageItem::from(package));
-        }
-
-        // hardcoded signature as a workaround for diwic/dbus-rs#24
-        // needs to stay in until the fix is released and works on stable
-        let args = [MessageItem::Array(message_items,
-                                       Cow::Owned("(a{ss}t)".to_string()))];
-
-        message.append_items(&args);
-        if connection.send(message).is_err() {
-            error!("Couldn't forward message to D-Bus");
-        }
-    }
-
-    fn send_complete(&self, package: PackageId) -> PackageReport {
-        let connection = Connection::get_private(BusType::Session).unwrap();
-        let mut message =
-            Message::new_method_call(&self.config.software_manager, "/",
-                                     &self.config.software_manager,
+            Message::new_method_call(&config.software_manager, "/",
+                                     &config.software_manager,
                                      "DownloadComplete").unwrap();
 
         let args = [MessageItem::from(&package)];
         message.append_items(&args);
 
         connection
-            .send_with_reply_and_block(message, self.config.timeout)
+            .send_with_reply_and_block(message, config.timeout)
             .parse(package)
     }
 
-    fn request_report(&self) -> Vec<PackageId> {
-        let connection = Connection::get_private(BusType::Session).unwrap();
-        let message =
-            Message::new_method_call(&self.config.software_manager, "/",
-                                     &self.config.software_manager,
-                                     "GetAllPackages").unwrap();
+pub fn request_report(config: &DBusConfiguration) -> Vec<PackageId> {
+    let connection = Connection::get_private(BusType::Session).unwrap();
+    let message =
+        Message::new_method_call(&config.software_manager, "/",
+                                 &config.software_manager,
+                                 "GetAllPackages").unwrap();
 
-        match connection.send_with_reply_and_block(message,
-                                                   self.config.timeout) {
-            Ok(ref val) => parse_package_list(val),
-            Err(..) => Vec::new()
-        }
+    match connection.send_with_reply_and_block(message,
+                                               config.timeout) {
+        Ok(ref val) => parse_package_list(val),
+        Err(..) => Vec::new()
     }
 }
 
@@ -129,7 +85,6 @@ fn parse_package_list(m: &Message) -> Vec<PackageId> {
 
 #[cfg(test)]
 mod test {
-    use std::sync::mpsc::channel;
     use dbus::{Message, MessageItem};
 
     use super::*;
@@ -142,25 +97,20 @@ mod test {
     #[test]
     fn it_sets_a_valid_notify_signature() {
         test_init!();
-        let (tx, _) = channel();
-        let (_, rx) = channel();
-        let sender = Sender::new(DBusConfiguration::gen_test(), rx, tx);
+        let conf = DBusConfiguration::gen_test();
         let packages = vec!(UserPackage {
             package: generate_random_package(15),
             size: 500
         });
 
-        sender.send_notify(packages);
+        send_notify(&conf, packages);
     }
 
     #[test]
     fn it_sets_a_valid_download_complete_signature() {
         test_init!();
-        let (tx, _) = channel();
-        let (_, rx) = channel();
-        let sender = Sender::new(DBusConfiguration::gen_test(), rx, tx);
-
-        let _ = sender.send_complete(generate_random_package(15));
+        let conf = DBusConfiguration::gen_test();
+        request_install(&conf, generate_random_package(15));
     }
 
     fn gen_test_message() -> Message {


### PR DESCRIPTION
The dbus sender now runs in the thread of the main_loop. This cuts down
on the messages being send from/into the main_loop and makes the code
more readable.