### PR TITLE
Replace the bare HashMap with a custom type

### DIFF
--- a/src/handler/abort.rs
+++ b/src/handler/abort.rs
@@ -1,9 +1,6 @@
 use std::sync::Mutex;
-use std::collections::HashMap;
-
 use message::{BackendServices, PackageId, Notification};
-use handler::HandleMessageParams;
-use persistence::Transfer;
+use handler::{Transfers, HandleMessageParams};
 
 #[derive(RustcDecodable)]
 pub struct AbortParams {
@@ -13,7 +10,7 @@ pub struct AbortParams {
 impl HandleMessageParams for AbortParams {
     fn handle(&self,
               _: &Mutex<BackendServices>,
-              transfers: &Mutex<HashMap<PackageId, Transfer>>,
+              transfers: &Mutex<Transfers>,
               _: &str, _: &str, _: &str) -> bool {
         let mut transfers = transfers.lock().unwrap();
 

--- a/src/handler/chunk.rs
+++ b/src/handler/chunk.rs
@@ -1,11 +1,9 @@
 use std::sync::Mutex;
-use std::collections::HashMap;
 
 #[cfg(not(test))] use rvi::send_message;
 
 use message::{BackendServices, PackageId, ChunkReceived, Notification};
-use handler::HandleMessageParams;
-use persistence::Transfer;
+use handler::{Transfers, HandleMessageParams};
 
 #[derive(RustcDecodable)]
 pub struct ChunkParams {
@@ -17,7 +15,7 @@ pub struct ChunkParams {
 impl HandleMessageParams for ChunkParams {
     fn handle(&self,
               services: &Mutex<BackendServices>,
-              transfers: &Mutex<HashMap<PackageId, Transfer>>,
+              transfers: &Mutex<Transfers>,
               rvi_url: &str, vin: &str, _: &str) -> bool {
         let services = services.lock().unwrap();
         let mut transfers = transfers.lock().unwrap();

--- a/src/handler/finish.rs
+++ b/src/handler/finish.rs
@@ -1,11 +1,9 @@
 use std::sync::Mutex;
-use std::collections::HashMap;
 
 #[cfg(not(test))] use rvi::send_message;
 
 use message::{BackendServices, PackageId, Notification, ServerPackageReport};
-use handler::HandleMessageParams;
-use persistence::Transfer;
+use handler::{Transfers, HandleMessageParams};
 
 #[derive(RustcDecodable)]
 pub struct FinishParams {
@@ -15,7 +13,7 @@ pub struct FinishParams {
 impl HandleMessageParams for FinishParams {
     fn handle(&self,
               services: &Mutex<BackendServices>,
-              transfers: &Mutex<HashMap<PackageId, Transfer>>,
+              transfers: &Mutex<Transfers>,
               rvi_url: &str, vin: &str, _: &str) -> bool {
         let services = services.lock().unwrap();
         let mut transfers = transfers.lock().unwrap();

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -11,10 +11,11 @@ use std::collections::HashMap;
 use message::{BackendServices, PackageId, Notification};
 use persistence::Transfer;
 
+pub type Transfers = HashMap<PackageId, Transfer>;
 pub trait HandleMessageParams {
     fn handle(&self,
               services: &Mutex<BackendServices>,
-              transfers: &Mutex<HashMap<PackageId, Transfer>>,
+              transfers: &Mutex<Transfers>,
               rvi_url: &str, vin: &str, storage_dir: &str)
         -> bool;
 

--- a/src/handler/notify.rs
+++ b/src/handler/notify.rs
@@ -1,10 +1,8 @@
 use std::fmt;
 use std::sync::Mutex;
-use std::collections::HashMap;
-use message::{BackendServices, PackageId, UserMessage, UserPackage};
+use message::{BackendServices, UserMessage, UserPackage};
 use message::Notification;
-use handler::HandleMessageParams;
-use persistence::Transfer;
+use handler::{Transfers, HandleMessageParams};
 
 impl fmt::Display for UserPackage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -21,7 +19,7 @@ pub struct NotifyParams {
 impl HandleMessageParams for NotifyParams {
     fn handle(&self,
               services: &Mutex<BackendServices>,
-              _: &Mutex<HashMap<PackageId, Transfer>>,
+              _: &Mutex<Transfers>,
               _: &str, _: &str, _: &str) -> bool {
         let mut services = services.lock().unwrap();
         services.update(&self.services);

--- a/src/handler/report.rs
+++ b/src/handler/report.rs
@@ -1,9 +1,7 @@
 use std::sync::Mutex;
-use std::collections::HashMap;
 
-use message::{BackendServices, PackageId, Notification};
-use handler::HandleMessageParams;
-use persistence::Transfer;
+use message::{BackendServices, Notification};
+use handler::{Transfers, HandleMessageParams};
 
 #[derive(RustcDecodable)]
 pub struct ReportParams;
@@ -11,7 +9,7 @@ pub struct ReportParams;
 impl HandleMessageParams for ReportParams {
     fn handle(&self,
               _: &Mutex<BackendServices>,
-              _: &Mutex<HashMap<PackageId, Transfer>>,
+              _: &Mutex<Transfers>,
               _: &str, _: &str, _: &str) -> bool {
         true
     }

--- a/src/handler/service.rs
+++ b/src/handler/service.rs
@@ -12,27 +12,24 @@ use hyper::server::{Handler, Request, Response};
 use rustc_serialize::{json, Decodable};
 use rustc_serialize::json::Json;
 
-use std::collections::HashMap;
-
 use rvi::{Message, RVIHandler, Service};
 
-use message::{BackendServices, PackageId, LocalServices, Notification};
+use message::{BackendServices, LocalServices, Notification};
 use handler::{NotifyParams, StartParams, ChunkParams, FinishParams};
-use handler::{ReportParams, AbortParams, HandleMessageParams};
-use persistence::Transfer;
+use handler::{ReportParams, AbortParams, HandleMessageParams, Transfers};
 use configuration::Configuration;
 
 pub struct ServiceHandler {
     rvi_url: String,
     sender: Mutex<Sender<Notification>>,
     services: Mutex<BackendServices>,
-    transfers: Arc<Mutex<HashMap<PackageId, Transfer>>>,
+    transfers: Arc<Mutex<Transfers>>,
     conf: Configuration,
     vin: String
 }
 
 impl ServiceHandler {
-    pub fn new(transfers: Arc<Mutex<HashMap<PackageId, Transfer>>>,
+    pub fn new(transfers: Arc<Mutex<Transfers>>,
                sender: Sender<Notification>,
                url: String, c: Configuration) -> ServiceHandler {
         let services = BackendServices {
@@ -53,7 +50,7 @@ impl ServiceHandler {
         }
     }
 
-    pub fn start_timer(transfers: &Mutex<HashMap<PackageId, Transfer>>,
+    pub fn start_timer(transfers: &Mutex<Transfers>,
                        timeout: i64) {
         loop {
             sleep_ms(1000);

--- a/src/handler/start.rs
+++ b/src/handler/start.rs
@@ -1,8 +1,7 @@
 use std::sync::Mutex;
-use std::collections::HashMap;
 
 use message::{BackendServices, PackageId, ChunkReceived, Notification};
-use handler::HandleMessageParams;
+use handler::{HandleMessageParams, Transfers};
 use persistence::Transfer;
 use rvi::send_message;
 
@@ -16,7 +15,7 @@ pub struct StartParams {
 impl HandleMessageParams for StartParams {
     fn handle(&self,
               services: &Mutex<BackendServices>,
-              transfers: &Mutex<HashMap<PackageId, Transfer>>,
+              transfers: &Mutex<Transfers>,
               rvi_url: &str, vin: &str, storage_dir: &str) -> bool {
         let services = services.lock().unwrap();
         let mut transfers = transfers.lock().unwrap();


### PR DESCRIPTION
This replaces the bare HashMap, used for storing the current transfers with a custom type.