### PR TITLE
Abort stops all transfers

### DIFF
--- a/src/handler/abort.rs
+++ b/src/handler/abort.rs
@@ -1,11 +1,9 @@
 use std::sync::Mutex;
-use message::{BackendServices, PackageId, Notification};
+use message::{BackendServices, Notification};
 use handler::{Transfers, HandleMessageParams};
 
 #[derive(RustcDecodable)]
-pub struct AbortParams {
-    pub package: PackageId,
-}
+pub struct AbortParams;
 
 impl HandleMessageParams for AbortParams {
     fn handle(&self,
@@ -13,18 +11,8 @@ impl HandleMessageParams for AbortParams {
               transfers: &Mutex<Transfers>,
               _: &str, _: &str, _: &str) -> bool {
         let mut transfers = transfers.lock().unwrap();
-
-        match transfers.remove(&self.package) {
-            Some(..) => {
-                info!("Transfer for package {} aborted", self.package);
-                true
-            },
-            None => {
-                error!("No transfer for package {}, ignoring abort",
-                       self.package);
-                false
-            }
-        }
+        transfers.clear();
+        true
     }
 
     fn get_message(&self) -> Option<Notification> { None }
@@ -42,7 +30,7 @@ mod test {
     use persistence::Transfer;
 
     #[test]
-    fn it_removes_existing_transfers() {
+    fn it_removes_a_single_transfer() {
         test_init!();
 
         let services = Mutex::new(get_empty_backend());
@@ -54,30 +42,26 @@ mod test {
         let transfers = Mutex::new(HashMap::new());
         transfers.lock().unwrap().insert(package.clone(), transfer);
 
-        let abort = AbortParams {
-            package: package
-        };
-
+        let abort = AbortParams;
         assert!(abort.handle(&services, &transfers, "", "", ""));
         assert!(transfers.lock().unwrap().is_empty());
     }
 
     #[test]
-    fn it_doesnt_do_anything_for_nonexistent_transfers() {
+    fn it_removes_all_transfers() {
+        test_init!();
         let services = Mutex::new(get_empty_backend());
-
         let prefix = PathPrefix::new();
-        let mut transfer = Transfer::new_test(&prefix);
-        let package = transfer.randomize(10);
 
         let transfers = Mutex::new(HashMap::new());
-        transfers.lock().unwrap().insert(package, transfer);
+        for i in 1..20 {
+            let mut transfer = Transfer::new_test(&prefix);
+            let package = transfer.randomize(i);
+            transfers.lock().unwrap().insert(package, transfer);
+        }
 
-        let abort = AbortParams {
-            package: generate_random_package(9)
-        };
-
-        assert!(! abort.handle(&services, &transfers, "", "", ""));
-        assert!(! transfers.lock().unwrap().is_empty());
+        let abort = AbortParams;
+        assert!(abort.handle(&services, &transfers, "", "", ""));
+        assert!(transfers.lock().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
Abort now doesn't accept a PackageId any more and drops all running
transfers. This change was made due to the client not knowing anything
about what transfers are dependencies for other transfers.