### PR TITLE
Fix configurations and the build for ARM

### DIFF
--- a/docker/client.toml
+++ b/docker/client.toml
@@ -1,10 +1,14 @@
 [client]
 storage_dir = "/var/sota"
+rvi_url = "http://127.0.0.1:8901"
+edge_url = "127.0.0.1:9080"
 timeout = 20
 vin_match = 2
 
 [dbus]
 name = "org.genivi.sota_client"
-interface = "org.genivi.software_manager"
-software_manager = "org.genivi.software_manager"
+path = "/org/genivi/sota_client"
+interface = "org.genivi.sota_client"
+software_manager = "org.genivi.software_loading_manager"
+software_manager_path = "/org/genivi/software_loading_manager"
 timeout = 60

--- a/src/configuration/common.rs
+++ b/src/configuration/common.rs
@@ -60,7 +60,7 @@ pub trait ParseTomlValue {
     /// * `val`: The `toml` value to parse.
     /// * `key`: The key this value is associated with.
     /// * `group`: The group, this (sub-) tree is associated with.
-    fn parse(val: &toml::Value, key: &str, group: &str) -> Result<Self>;
+    fn parse(val: &toml::Value, key: &str, group: &str) -> Result<Self> where Self: Sized;
 }
 
 impl ParseTomlValue for String {


### PR DESCRIPTION
Hi,

I found a couple of issues while I was working on an update of the RVI SOTA client recipe for GENIVI Demo Platform:

* The first patch fixes the configuration file in directory docker. Otherwise the following error will appear: 
```
ERROR:sota_client: Couldn't parse configuration file at /var/sota/client.toml: Missing required key "path" in "dbus"
```

* The second patch fixes the following issue in src/configuration/common.rs while building RVI SOTA client for Raspberry Pi 2 and other ARM devices:

```
| src/configuration/common.rs:63:5: 63:73 error: the trait `core::marker::Sized` is not implemented for the type `Self` [E0277]
| src/configuration/common.rs:63     fn parse(val: &toml::Value, key: &str, group: &str) -> Result<Self>;
|                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| src/configuration/common.rs:63:5: 63:73 help: run `rustc --explain E0277` to see a detailed explanation
| src/configuration/common.rs:63:5: 63:73 note: `Self` does not have a constant size known at compile-time
| src/configuration/common.rs:63:5: 63:73 note: required by `core::result::Result`
| error: aborting due to previous error
| Could not compile `sota_client`.
```

Best regards, Leon