### PR TITLE
Allow gateway template values to be overridden

### DIFF
--- a/pkg/ota.toml.template
+++ b/pkg/ota.toml.template
@@ -9,9 +9,9 @@ uuid = "${OTA_DEVICE_UUID}"
 vin = "${OTA_CLIENT_VIN}"
 
 [gateway]
-console = false
-http = false
-websocket = true
+console = ${OTA_CONSOLE}
+http = ${OTA_HTTP}
+websocket = ${OTA_WEBSOCKET}
 
 [ota]
 server = "${OTA_CORE_URL}"


### PR DESCRIPTION
@jerrytrieu: setting these as env-vars again as Alex and Robert require this for the ota-integration-builder side of things