### PR TITLE
[PRO-910] Fix tailor.sh alien command line flag

### DIFF
--- a/pkg/tailor.sh
+++ b/pkg/tailor.sh
@@ -10,7 +10,7 @@ PKG_SRC_DIR=$(pwd)
 
 function convert_to_rpm {
     mv $dest $dest.deb
-    alien -c -k -r --fix-perms $dest.deb
+    alien -c -k -r --fixperms $dest.deb
     mv ota-plus*.rpm $dest
 }
 


### PR DESCRIPTION
Resolves  #PRO-910.

@jerrytrieu: I haven't tested this fix locally as I can can't log in to Auth0 to download a package but running the `tailor.sh` script manually failed at this step.