### PR TITLE
[PRO-1001] Remove confidential data from log output

### DIFF
--- a/src/gateway/dbus.rs
+++ b/src/gateway/dbus.rs
@@ -31,7 +31,7 @@ impl Gateway for DBus {
             loop {
                 for item in conn.iter(1000) {
                     if let ConnectionItem::MethodCall(mut msg) = item {
-                        info!("dbus method call: {:?}", msg);
+                        info!("DBus method call: {:?}", msg);
                         obj_path.handle_message(&mut msg).map(|result| {
                             let _ = result.map_err(|_| error!("dbus method call failed: {:?}", msg));
                         });

--- a/src/gateway/http.rs
+++ b/src/gateway/http.rs
@@ -50,7 +50,7 @@ impl<T: Transport> Server<T> for HttpHandler {
     fn request(&mut self, body: Vec<u8>) {
         String::from_utf8(body).map(|body| {
             json::decode::<Command>(&body).map(|cmd| {
-                info!("http request decoded command: {:?}", cmd);
+                info!("Incoming HTTP request command: {}", cmd);
                 let (etx, erx)   = chan::async::<Event>();
                 self.response_rx = Some(erx);
                 self.itx.lock().unwrap().send(Interpret {

--- a/src/http/http_server.rs
+++ b/src/http/http_server.rs
@@ -43,7 +43,7 @@ impl<T: Transport> Handler<T> for ServerHandler<T> {
     fn on_request_readable(&mut self, transport: &mut Decoder<T>) -> Next {
         match io::copy(transport, &mut self.req_body) {
             Ok(0) => {
-                debug!("on_request_readable bytes read: {:?}", self.req_body.len());
+                debug!("on_request_readable bytes read: {}", self.req_body.len());
                 self.server.request(mem::replace(&mut self.req_body, Vec::new()));
                 Next::write().timeout(Duration::from_secs(20))
             }


### PR DESCRIPTION
Resolves [PRO-1001](https://advancedtelematic.atlassian.net/browse/PRO-1001).

The main confidential data I could find in the log output was embedded query parameter credentials when redirecting to S3, so this PR sets the `Display` trait for `Url` to hide the query parameters from the log output.