### PR TITLE
Fix AccessToken scope to be a single space-delimited string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,3 +582,4 @@ dependencies = [
  "winapi 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+

--- a/src/datatype/auth.rs
+++ b/src/datatype/auth.rs
@@ -23,7 +23,7 @@ pub struct AccessToken {
     pub access_token: String,
     pub token_type:   String,
     pub expires_in:   i32,
-    pub scope:        Vec<String>
+    pub scope:        String
 }
 
 impl<'a> Into<Cow<'a, AccessToken>> for AccessToken {

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -28,13 +28,13 @@ mod tests {
 
     #[test]
     fn test_authenticate() {
-        let token  = r#"{"access_token": "token", "token_type": "type", "expires_in": 10, "scope": ["scope"]}"#;
+        let token  = r#"{"access_token": "token", "token_type": "type", "expires_in": 10, "scope": "scope1 scope2"}"#;
         let client = TestClient::from(vec![token.to_string()]);
         let expect = AccessToken {
             access_token: "token".to_string(),
             token_type:   "type".to_string(),
             expires_in:   10,
-            scope:        vec!["scope".to_string()]
+            scope:        "scope1 scope2".to_string()
         };
         assert_eq!(expect, authenticate(test_server(), &client).unwrap());
     }


### PR DESCRIPTION
Resolves [PRO-1203](https://advancedtelematic.atlassian.net/browse/PRO-1203)