### PR TITLE
[PRO-1825] Change name of packagemanager to ostree

### DIFF
--- a/run/sota_ostree.sh
+++ b/run/sota_ostree.sh
@@ -29,7 +29,7 @@ fi
 
 HDR="Authorization=Bearer $AUTHPLUS_ACCESS_TOKEN"
 
-rm /etc/ostree/remotes.d/agl-remote.conf
+rm -f /etc/ostree/remotes.d/agl-remote.conf
 ostree remote add --no-gpg-verify agl-remote "$PULL_URI"
 ostree pull agl-remote --http-header="$HDR" "$COMMIT"
 ostree admin deploy "$COMMIT"

--- a/src/package_manager/package_manager.rs
+++ b/src/package_manager/package_manager.rs
@@ -84,7 +84,7 @@ impl FromStr for PackageManager {
             "off" => Ok(PackageManager::Off),
             "deb" => Ok(PackageManager::Deb),
             "rpm" => Ok(PackageManager::Rpm),
-            "treehub" => Ok(PackageManager::TreeHub),
+            "ostree" => Ok(PackageManager::TreeHub),
 
             file if file.len() > 5 && file[..5].as_bytes() == b"file:" => {
                 Ok(PackageManager::File { filename: file[5..].to_string(), succeeds: true })


### PR DESCRIPTION
The previous commit in this ticket got merged to quickly, these two
changes were supposed to be added.