### PR TITLE
Save deployed commit hash to prevent it to be deployed multiple times

### DIFF
--- a/run/sota_ostree.sh
+++ b/run/sota_ostree.sh
@@ -31,7 +31,7 @@ HDR="Authorization=Bearer $AUTHPLUS_ACCESS_TOKEN"
 
 mkdir -p /var/sota_ostree/
 
-CUR_COMMIT=$(cat /var/sota_ostee/staging)
+CUR_COMMIT=$(cat /var/sota_ostree/staging)
 
 if [ "$COMMIT" == "$CUR_COMMIT" ]; then
     echo "already installed"

--- a/run/sota_ostree.sh
+++ b/run/sota_ostree.sh
@@ -29,7 +29,16 @@ fi
 
 HDR="Authorization=Bearer $AUTHPLUS_ACCESS_TOKEN"
 
+mkdir -p /var/sota_ostree/
+
+CUR_COMMIT=$(cat /var/sota_ostee/staging)
+
+if [ "$COMMIT" == "$CUR_COMMIT" ]; then
+    echo "already installed"
+    exit 0
+fi
+
 rm -f /etc/ostree/remotes.d/agl-remote.conf
 ostree remote add --no-gpg-verify agl-remote "$PULL_URI"
 ostree pull agl-remote --http-header="$HDR" "$COMMIT"
-ostree admin deploy "$COMMIT"
+ostree admin deploy "$COMMIT" && echo -n "$COMMIT" > /var/sota_ostree/staging


### PR DESCRIPTION
Tested, at least doesn't break anything