### PR TITLE
Complete provisioning flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "serde 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -511,6 +512,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "2.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread-id"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +725,7 @@ dependencies = [
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum syn 0.11.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f957107cdcbe1c840e3209f0dd7a84c1668ef0b34170b43e1bae634075067c10"
 "checksum synom 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8fece1853fb872b0acdc3ff88f37c474018e125ef81cd4cb8c0ca515746b62ed"
+"checksum tempfile 2.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3213fd2b7ed87e39306737ccfac04b1233b57a33ca64cfbf52f2ffaa2b765e2f"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ getopts = "0.2.14"
 hyper = { version = "0.9.13", default-features = false }
 lazy_static = "0.2.2"
 log = "0.3.6"
+tempfile = "2.1.5"
 nom = "1.2.4"
 openssl = "0.9.7"
 rand = "0.3.15"

--- a/src/datatype/config.rs
+++ b/src/datatype/config.rs
@@ -1,11 +1,9 @@
 use rustc_serialize::Decodable;
 use std::fs::File;
 use std::io::prelude::*;
-use std::ops::Deref;
 use toml::{Decoder, Parser, Table};
 
 use datatype::{Auth, ClientCredentials, Error, SocketAddr, Url};
-use http::TlsData;
 use package_manager::PackageManager;
 
 
@@ -73,30 +71,13 @@ impl Config {
             (Some(_), Some(_), _)       => Err("Need one of [auth] or [tls] section only."),
             (Some(_), _,       Some(_)) => Err("Need one of [auth] or [provision] section only."),
             (None,    None,    None)    => Ok(Auth::None),
-            (_,       Some(_), None)    => Ok(Auth::Certificate),
-            (_,       _,       Some(_)) => Ok(Auth::Provision),
+            (None,    Some(_), None)    => Ok(Auth::Certificate),
+            (None,    _,       Some(_)) => Ok(Auth::Provision),
 
             (Some(&AuthConfig { client_id: ref id, client_secret: ref secret, .. }), _, _) => {
                 Ok(Auth::Credentials(ClientCredentials { client_id: id.clone(), client_secret: secret.clone() }))
             }
         }
-    }
-
-    /// Return the certificate paths used for TLS configuration.
-    pub fn tls_data(&self, provisioning: bool) -> TlsData {
-        let ca_path = self.device.certificates_path.as_ref().map(Deref::deref);
-        let mut tls = TlsData { ca_path: ca_path, p12_path: None, p12_pass: None };
-
-        match (provisioning, self.tls.as_ref()) {
-            (false, Some(&TlsConfig { p12_path: ref path, p12_password: ref pass, .. })) => {
-                tls.p12_path = Some(path);
-                tls.p12_pass = Some(pass);
-            }
-
-            _ => ()
-        }
-
-        tls
     }
 }
 
@@ -489,19 +470,21 @@ impl Defaultify<NetworkConfig> for ParsedNetworkConfig {
 /// The [provision] configuration section.
 #[derive(RustcDecodable, PartialEq, Eq, Debug, Clone)]
 pub struct ProvisionConfig {
-    pub p12_path:     String,
-    pub p12_password: String,
-    pub expiry_days:  u32,
-    pub device_id:    Option<String>,
+    pub p12_path:            String,
+    pub p12_password:        String,
+    pub expiry_days:         u32,
+    pub device_id:           Option<String>,
+    pub retry_delay_seconds: u64,
 }
 
 impl Default for ProvisionConfig {
     fn default() -> Self {
         ProvisionConfig {
-            p12_path:     "/usr/local/etc/sota/registration.p12".to_string(),
-            p12_password: "".to_string(),
-            expiry_days:  365,
-            device_id:    None,
+            p12_path:            "/usr/local/etc/sota/registration.p12".to_string(),
+            p12_password:        "".to_string(),
+            expiry_days:         365,
+            device_id:           None,
+            retry_delay_seconds: 5,
         }
     }
 }
@@ -512,15 +495,17 @@ struct ParsedProvisionConfig {
     p12_password: Option<String>,
     expiry_days:  Option<u32>,
     device_id:    Option<String>,
+    retry_delay_seconds: Option<u64>,
 }
 
 impl Default for ParsedProvisionConfig {
     fn default() -> Self {
         ParsedProvisionConfig {
-            p12_path:     None,
-            p12_password: None,
-            expiry_days:  None,
-            device_id:    None,
+            p12_path:            None,
+            p12_password:        None,
+            expiry_days:         None,
+            device_id:           None,
+            retry_delay_seconds: None,
         }
     }
 }
@@ -529,10 +514,11 @@ impl Defaultify<ProvisionConfig> for ParsedProvisionConfig {
     fn defaultify(&mut self) -> ProvisionConfig {
         let default = ProvisionConfig::default();
         ProvisionConfig {
-            p12_path:     self.p12_path.take().unwrap_or(default.p12_path),
-            p12_password: self.p12_password.take().unwrap_or(default.p12_password),
-            expiry_days:  self.expiry_days.take().unwrap_or(default.expiry_days),
-            device_id:    self.device_id.take().or(default.device_id),
+            p12_path:            self.p12_path.take().unwrap_or(default.p12_path),
+            p12_password:        self.p12_password.take().unwrap_or(default.p12_password),
+            expiry_days:         self.expiry_days.take().unwrap_or(default.expiry_days),
+            device_id:           self.device_id.take().or(default.device_id),
+            retry_delay_seconds: self.retry_delay_seconds.take().unwrap_or(default.retry_delay_seconds),
         }
     }
 }
@@ -588,34 +574,38 @@ impl Defaultify<RviConfig> for ParsedRviConfig {
 /// The [tls] configuration section.
 #[derive(RustcDecodable, PartialEq, Eq, Debug, Clone)]
 pub struct TlsConfig {
-    pub server:       Url,
-    pub p12_path:     String,
-    pub p12_password: String,
+    pub server:            Url,
+    pub p12_path:          String,
+    pub p12_password:      String,
+    pub certificates_path: Option<String>,
 }
 
 impl Default for TlsConfig {
     fn default() -> Self {
         TlsConfig {
-            server:       "http://127.0.0.1:8000".parse().unwrap(),
-            p12_path:     "/usr/local/etc/sota/device.p12".to_string(),
-            p12_password: "".to_string(),
+            server:            "http://127.0.0.1:8000".parse().unwrap(),
+            p12_path:          "/usr/local/etc/sota/device.p12".to_string(),
+            p12_password:      "".to_string(),
+            certificates_path: None,
         }
     }
 }
 
 #[derive(RustcDecodable, Debug)]
 struct ParsedTlsConfig {
-    server:       Option<Url>,
-    p12_path:     Option<String>,
-    p12_password: Option<String>,
+    server:            Option<Url>,
+    p12_path:          Option<String>,
+    p12_password:      Option<String>,
+    certificates_path: Option<String>,
 }
 
 impl Default for ParsedTlsConfig {
     fn default() -> Self {
         ParsedTlsConfig {
-            server:       None,
-            p12_path:     None,
-            p12_password: None,
+            server:            None,
+            p12_path:          None,
+            p12_password:      None,
+            certificates_path: None,
         }
     }
 }
@@ -624,9 +614,10 @@ impl Defaultify<TlsConfig> for ParsedTlsConfig {
     fn defaultify(&mut self) -> TlsConfig {
         let default = TlsConfig::default();
         TlsConfig {
-            server:       self.server.take().unwrap_or(default.server),
-            p12_path:     self.p12_path.take().unwrap_or(default.p12_path),
-            p12_password: self.p12_password.take().unwrap_or(default.p12_password),
+            server:            self.server.take().unwrap_or(default.server),
+            p12_path:          self.p12_path.take().unwrap_or(default.p12_path),
+            p12_password:      self.p12_password.take().unwrap_or(default.p12_password),
+            certificates_path: self.certificates_path.take().or(default.certificates_path),
         }
     }
 }
@@ -750,7 +741,8 @@ mod tests {
         [provision]
         p12_path = "/usr/local/etc/sota/registration.p12"
         p12_password = ""
-        expiry_days = 365
+        expiry_days = 11
+        retry_delay_seconds = 17
         "#;
 
     const RVI_CONFIG: &'static str =

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -6,4 +6,4 @@ pub mod tls;
 pub use self::auth_client::AuthClient;
 pub use self::http_client::{Client, Request, Response, ResponseData};
 pub use self::test_client::TestClient;
-pub use self::tls::{TlsClient, TlsData, init_tls_client};
+pub use self::tls::{TlsClient, TlsData, init_tls_client, init_tls_client_from_p12};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate rustc_serialize;
 extern crate serde;
 #[macro_use] extern crate serde_derive;
 extern crate serde_json;
+extern crate tempfile;
 extern crate time;
 extern crate toml;
 extern crate unix_socket;

--- a/tests/config/auth.toml
+++ b/tests/config/auth.toml
@@ -6,7 +6,8 @@ client_secret = "client-secret"
 [provision]
 p12_path = "/usr/local/etc/sota/registration.p12"
 p12_password = ""
-expiry_days = 365
+expiry_days = 11
+retry_delay_seconds = 17
 #device_id = None
 
 [tls]


### PR DESCRIPTION
- use certificate in pkcs#12 file when no other available
- changed it to not bail when `tls.p12_path` exists already, but to not download the certificate again.
- added retry for certificate download
- added own certificate path to tls section