### PR TITLE
Added temporary Dockerfile for tests to work around missing canonical_json.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ PACKAGE_VERSION := $(shell git describe --tags | cut -c2-)
 IMAGE_RUST := advancedtelematic/rust:x86-1.15.1
 IMAGE_SOTA := advancedtelematic/sota-client:latest
 IMAGE_FPM  := advancedtelematic/fpm:latest
+IMAGE_TEST := advancedtelematic/sota-client-test:latest
 
 # target client binary format
 TARGET := x86_64-unknown-linux-gnu
@@ -42,7 +43,7 @@ old: image ## Use a local `sota.toml` config file to run the client.
 	$(DOCKER_RUN) --net=host --volume sota.toml:/usr/local/etc/sota.toml $(IMAGE_SOTA)
 
 test: ## Run all unit tests.
-	$(CARGO) test --target=$(TARGET)
+	$(DOCKER_RUN) $(IMAGE_TEST) test --target=$(TARGET)
 
 doc: ## Generate documentation for the sota crate.
 	$(CARGO) doc --lib --no-deps --release

--- a/docker-test/Dockerfile
+++ b/docker-test/Dockerfile
@@ -1,0 +1,20 @@
+FROM jimmycuadra/rust:1.15.0
+
+RUN apt-get update && apt-get install -y \
+    libdbus-1-3 \
+    libdbus-1-dev \
+    dbus-x11 \
+    python3 \
+    python3-pip \
+    libssl-dev \
+    openssl \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install canonicaljson
+
+ARG bin_dir=/usr/local/bin
+ARG conf_dir=/usr/local/etc
+
+COPY canonical_json.py $bin_dir
+
+ENTRYPOINT ["/usr/local/bin/cargo"]

--- a/docker-test/canonical_json.py
+++ b/docker-test/canonical_json.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import canonicaljson
+import json
+import os
+import sys
+
+if __name__ == '__main__':
+    with os.fdopen(sys.stdin.fileno(), 'rb') as f:
+        bytes_in = f.read()
+
+    bytes_out = canonicaljson.encode_canonical_json(json.loads(bytes_in.decode('utf-8')))
+
+    with os.fdopen(sys.stdout.fileno(), 'wb') as f:
+        f.write(bytes_out)
+        f.flush()


### PR DESCRIPTION
Fixes PRO-2471

Current docker runs of `make test` fail because required canonical_json.py is missing. This PR causes the tests to run in a docker image that includes the required python file. This should be removed as soon as the dependency on canonical_json.py is removed (PRO-2472)