### PR TITLE
Reduce binary size with conditional compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,19 +10,19 @@ dependencies = [
  "dbus 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -79,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -106,7 +106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -116,7 +116,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -184,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -241,7 +241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -433,7 +433,7 @@ name = "ring"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -470,7 +470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -478,17 +478,17 @@ name = "serde_codegen_internals"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "syn 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -509,7 +509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -578,10 +578,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "toml"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -596,7 +596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,7 +664,7 @@ name = "url"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -701,7 +701,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -727,7 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bit-vec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b97c2c8e8bbb4251754f559df8af22fb264853c7d009084a576cdf12565089d"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
-"checksum bytes 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46112a0060ae15e3a3f9a445428a53e082b91215b744fa27a1948842f4a64b96"
+"checksum bytes 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3941933da81d8717b427c2ddc2d73567cd15adb6c57514a2726d9ee598a5439a"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chan 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f93bfe971116428a9066c1c3c69a09ae3ef69432f8418be28ab50f96783e6a50"
 "checksum chan-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f3bb6c3bc387004ad914f0c5b7f33ace8bf7604bbec35f228b1a017f52cd3a0"
@@ -742,13 +742,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"
 "checksum getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9047cfbd08a437050b363d35ef160452c5fe8ea5187ae0a624708c91581d685"
 "checksum httparse 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6e7a63e511f9edffbab707141fbb8707d1a3098615fb2adbd5769cdfcc9b17d"
-"checksum hyper 0.10.5 (registry+https://github.com/rust-lang/crates.io-index)" = "43a15e3273b2133aaac0150478ab443fb89f15c3de41d8d93d8f3bb14bf560f6"
-"checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
+"checksum hyper 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a7a2876a571abcfb6fb9a2a2ecce822abb174455b6a69d91ad1810cd29549a06"
+"checksum idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac85ec3f80c8e4e99d9325521337e14ec7555c458a14e377d189659a427f375"
 "checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4732c563b9a21a406565c4747daa7b46742f082911ae4753f390dc9ec7ee1a97"
+"checksum lazy_static 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2f61b8421c7a4648c391611625d56fdd5c7567da05af1be655fd8cacc643abb3"
 "checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
 "checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
@@ -778,12 +778,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "684ce48436d6465300c9ea783b6b14c4361d6b8dcbb1375b486a69cc19e2dfb0"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-"checksum serde 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f023838e7e1878c679322dc7f66c3648bd33763a215fad752f378a623856898d"
+"checksum serde 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "231dfd55909400769e437326cfb4af8bec97c3dd56ab3d02df8ef5c7e00f179b"
 "checksum serde_codegen_internals 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
-"checksum serde_derive 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)" = "ebb753639f6d55ba1acbcd330ccaf4d9f5862353ac2851e43eac63c2a5343a11"
+"checksum serde_derive 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "d75c72ef4dd193d89eb652b73890fe2489996c9ead8b37980f57a1078f96ed50"
 "checksum serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "dbc45439552eb8fb86907a2c41c1fd0ef97458efb87ff7f878db466eb581824e"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
-"checksum syn 0.11.9 (registry+https://github.com/rust-lang/crates.io-index)" = "480c834701caba3548aa991e54677281be3a5414a9d09ddbdf4ed74a569a9d19"
+"checksum syn 0.11.10 (registry+https://github.com/rust-lang/crates.io-index)" = "171b739972d9a1bfb169e8077238b51f9ebeaae4ff6e08072f7ba386a8802da2"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
@@ -791,7 +791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
-"checksum toml 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3474f3c6eaf32eedb4f4a66a26214f020f828a6d96c37e38a35e3a379bbcfd11"
+"checksum toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd86ad9ebee246fdedd610e0f6d0587b754a3d81438db930a244d0480ed7878f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum tungstenite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e98bf689c6fccc64f7d5aa7be5df2dfb43a14d0e8c6e94916a4d10c9b615fda6"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,24 +18,34 @@ chan = "0.1.18"
 chan-signal = "0.2.0"
 chrono = { version = "0.3", features = ["serde"] }
 crossbeam = "0.2.10"
-dbus = "0.5.1"
+dbus = { version = "0.5.1", optional = true }
 env_logger = "0.4.2"
 getopts = "0.2.14"
-hyper = { version = "0.10.5", default-features = false }
-lazy_static = "0.2.2"
+hyper = { version = "0.10.6", default-features = false }
+lazy_static = "0.2.6"
 log = "0.3.6"
 nom = "1.2.4"
 openssl = "0.9.10"
 pem = "0.2.0"
 ring = { version = "0.7.1", features = [ "rsa_signing" ] }
 rust-crypto = "0.2.36"
-serde_derive = "0.9.12"
-serde = "0.9.12"
+serde_derive = "0.9.13"
+serde = "0.9.13"
 serde_json = "0.9.9"
 time = "0.1.36"
 toml = "0.3.1"
-tungstenite = { version = "0.1.1", default-features = false }
-unix_socket = "0.5.0"
+tungstenite = { version = "0.1.1", default-features = false, optional = true }
+unix_socket = { version = "0.5.0", optional = true }
 untrusted = "0.3.2"
 url = "1.2.1"
 uuid = { version = "0.4.0", features = ["serde", "v4"] }
+
+[features]
+default = ["d-bus", "socket", "websocket"]
+d-bus = ["dbus"]
+socket = ["unix_socket"]
+websocket = ["tungstenite"]
+
+[profile.release]
+lto = true
+opt-level = 3

--- a/src/datatype/error.rs
+++ b/src/datatype/error.rs
@@ -10,6 +10,7 @@ use std::string::FromUtf8Error;
 use std::sync::PoisonError;
 use std::sync::mpsc::{SendError, RecvError};
 use toml::de::Error as TomlError;
+#[cfg(feature = "websocket")]
 use tungstenite::Error as WebsocketError;
 use url::ParseError as UrlParseError;
 
@@ -55,7 +56,53 @@ pub enum Error {
     UrlParse(UrlParseError),
     Utf8(Utf8Error),
     Verify(String),
+    #[cfg(feature = "websocket")]
     Websocket(WebsocketError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let inner: String = match *self {
+            Error::ChronoParse(ref e)   => format!("DateTime parse error: {}", e.clone()),
+            Error::Client(ref s)        => format!("Http client error: {}", s.clone()),
+            Error::Command(ref e)       => format!("Unknown Command: {}", e.clone()),
+            Error::Config(ref s)        => format!("Bad Config: {}", s.clone()),
+            Error::FromUtf8(ref e)      => format!("From utf8 error: {}", e.clone()),
+            Error::Http(ref r)          => format!("HTTP client error: {}", r.clone()),
+            Error::HttpAuth(ref r)      => format!("HTTP authorization error: {}", r.clone()),
+            Error::Hyper(ref e)         => format!("Hyper error: {}", e.clone()),
+            Error::Io(ref e)            => format!("IO error: {}", e.clone()),
+            Error::Openssl(ref e)       => format!("OpenSSL errors: {}", e.clone()),
+            Error::OSTree(ref e)        => format!("OSTree error: {}", e.clone()),
+            Error::Poison(ref e)        => format!("Poison error: {}", e.clone()),
+            Error::PacMan(ref s)        => format!("Package manager error: {}", s.clone()),
+            Error::Parse(ref s)         => format!("Parse error: {}", s.clone()),
+            Error::Recv(ref s)          => format!("Recv error: {}", s.clone()),
+            Error::Rvi(ref s)           => format!("RVI error: {}", s.clone()),
+            Error::SendEvent(ref s)     => format!("Send error for Event: {}", s.clone()),
+            Error::SendInterpret(ref s) => format!("Send error for Interpret: {}", s.clone()),
+            Error::SerdeJson(ref e)     => format!("Serde JSON error: {}", e.clone()),
+            Error::Socket(ref s)        => format!("Unix Domain Socket error: {}", s.clone()),
+            Error::SystemInfo(ref s)    => format!("System info error: {}", s.clone()),
+            Error::Toml(ref e)          => format!("TOML error: {:?}", e.clone()),
+            Error::UrlParse(ref s)      => format!("Url parse error: {}", s.clone()),
+            Error::Utf8(ref e)          => format!("Utf8 error: {}", e.clone()),
+            Error::Verify(ref s)        => format!("Verification error: {}", s.clone()),
+            #[cfg(feature = "websocket")]
+            Error::Websocket(ref e)     => format!("Websocket Error: {:?}", e.clone()),
+
+            Error::UptaneExpired               => "Uptane: expired".into(),
+            Error::UptaneInvalidKeyType(ref s) => format!("Uptane: invalid key type: {}", s),
+            Error::UptaneInvalidSigType(ref s) => format!("Uptane: invalid signature type: {}", s),
+            Error::UptaneInvalidRole           => "Uptane: invalid role".into(),
+            Error::UptaneMissingSignatures     => "Uptane: missing signatures".into(),
+            Error::UptaneMissingField(s)       => format!("Uptane: metadata missing field: {}", s),
+            Error::UptaneRoleThreshold         => "Uptane: role threshold not met".into(),
+            Error::UptaneUnknownRole           => "Uptane: unknown role".into(),
+            Error::UptaneVerifySignatures      => "Uptane: invalid signature".into(),
+        };
+        write!(f, "{}", inner)
+    }
 }
 
 impl<E> From<PoisonError<E>> for Error {
@@ -63,6 +110,7 @@ impl<E> From<PoisonError<E>> for Error {
         Error::Poison(format!("{}", e))
     }
 }
+
 
 macro_rules! derive_from {
     ([ $( $from: ident => $to: ident ),* ]) => {
@@ -93,55 +141,13 @@ derive_from!([
     SerdeJsonError   => SerdeJson,
     TomlError        => Toml,
     UrlParseError    => UrlParse,
-    Utf8Error        => Utf8,
-    WebsocketError   => Websocket
+    Utf8Error        => Utf8
 ]);
+
+#[cfg(feature = "websocket")]
+derive_from!([WebsocketError => Websocket]);
 
 derive_from!([
     SendError<Event>     => SendEvent,
     SendError<Interpret> => SendInterpret
 ]);
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let inner: String = match *self {
-            Error::ChronoParse(ref e)   => format!("DateTime parse error: {}", e.clone()),
-            Error::Client(ref s)        => format!("Http client error: {}", s.clone()),
-            Error::Command(ref e)       => format!("Unknown Command: {}", e.clone()),
-            Error::Config(ref s)        => format!("Bad Config: {}", s.clone()),
-            Error::FromUtf8(ref e)      => format!("From utf8 error: {}", e.clone()),
-            Error::Http(ref r)          => format!("HTTP client error: {}", r.clone()),
-            Error::HttpAuth(ref r)      => format!("HTTP authorization error: {}", r.clone()),
-            Error::Hyper(ref e)         => format!("Hyper error: {}", e.clone()),
-            Error::Io(ref e)            => format!("IO error: {}", e.clone()),
-            Error::Openssl(ref e)       => format!("OpenSSL errors: {}", e.clone()),
-            Error::OSTree(ref e)        => format!("OSTree error: {}", e.clone()),
-            Error::Poison(ref e)        => format!("Poison error: {}", e.clone()),
-            Error::PacMan(ref s)        => format!("Package manager error: {}", s.clone()),
-            Error::Parse(ref s)         => format!("Parse error: {}", s.clone()),
-            Error::Recv(ref s)          => format!("Recv error: {}", s.clone()),
-            Error::Rvi(ref s)           => format!("RVI error: {}", s.clone()),
-            Error::SendEvent(ref s)     => format!("Send error for Event: {}", s.clone()),
-            Error::SendInterpret(ref s) => format!("Send error for Interpret: {}", s.clone()),
-            Error::SerdeJson(ref e)     => format!("Serde JSON error: {}", e.clone()),
-            Error::Socket(ref s)        => format!("Unix Domain Socket error: {}", s.clone()),
-            Error::SystemInfo(ref s)    => format!("System info error: {}", s.clone()),
-            Error::Toml(ref e)          => format!("TOML error: {:?}", e.clone()),
-            Error::UrlParse(ref s)      => format!("Url parse error: {}", s.clone()),
-            Error::Utf8(ref e)          => format!("Utf8 error: {}", e.clone()),
-            Error::Verify(ref s)        => format!("Verification error: {}", s.clone()),
-            Error::Websocket(ref e)     => format!("Websocket Error: {:?}", e.clone()),
-
-            Error::UptaneExpired               => "Uptane: expired".into(),
-            Error::UptaneInvalidKeyType(ref s) => format!("Uptane: invalid key type: {}", s),
-            Error::UptaneInvalidSigType(ref s) => format!("Uptane: invalid signature type: {}", s),
-            Error::UptaneInvalidRole           => "Uptane: invalid role".into(),
-            Error::UptaneMissingSignatures     => "Uptane: missing signatures".into(),
-            Error::UptaneMissingField(s)       => format!("Uptane: metadata missing field: {}", s),
-            Error::UptaneRoleThreshold         => "Uptane: role threshold not met".into(),
-            Error::UptaneUnknownRole           => "Uptane: unknown role".into(),
-            Error::UptaneVerifySignatures      => "Uptane: invalid signature".into(),
-        };
-        write!(f, "{}", inner)
-    }
-}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,13 +1,19 @@
 pub mod console;
+#[cfg(feature = "d-bus")]
 pub mod dbus;
 pub mod http;
+#[cfg(feature = "socket")]
 pub mod socket;
+#[cfg(feature = "websocket")]
 pub mod websocket;
 
 pub use self::console::Console;
+#[cfg(feature = "d-bus")]
 pub use self::dbus::DBus;
 pub use self::http::Http;
+#[cfg(feature = "socket")]
 pub use self::socket::Socket;
+#[cfg(feature = "websocket")]
 pub use self::websocket::Websocket;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,30 @@
-#[macro_use] extern crate nom; // use before log to avoid error!() macro conflict
+#[macro_use]
+extern crate nom; // use before log to avoid error!() macro conflict
 
 extern crate base64;
 extern crate chan;
 extern crate chrono;
 extern crate crossbeam;
 extern crate crypto;
+#[cfg(feature = "d-bus")]
 extern crate dbus;
 extern crate hyper;
 extern crate openssl;
 extern crate pem;
-#[macro_use] extern crate lazy_static;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate log;
 extern crate ring;
 extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate time;
 extern crate toml;
+#[cfg(feature = "websocket")]
 extern crate tungstenite;
+#[cfg(feature = "socket")]
 extern crate unix_socket;
 extern crate untrusted;
 extern crate url;


### PR DESCRIPTION
Defaults to current behaviour. `meta-rust` still doesn't support abort on panic which would reduce the binary size further, so current stack unwinding behaviour is kept for now.