### PR TITLE
PRO-3196 Wait for timesyncd before autoprovisioning

### DIFF
--- a/run/sota_prov.sh
+++ b/run/sota_prov.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+while [[ "$(timedatectl status | grep NTP)" != "NTP synchronized: yes" ]]; do 
+  sleep 5
+  echo "Waiting for NTP sync..."
+done
+
 set -xeo pipefail
 
 : "${SOTA_GATEWAY_URI:?}"


### PR DESCRIPTION
Because of https://github.com/systemd/systemd/issues/5097 (time-sync.target doesn't work as expected), we have to check this manually in the provisioning script. A bit hackish, but it does the job.