### PR TITLE
Revert "Remove deprecated refname field"

### DIFF
--- a/sota-client/src/datatype/ostree.rs
+++ b/sota-client/src/datatype/ostree.rs
@@ -18,6 +18,7 @@ use pacman::Credentials;
 
 const REMOTE_NAME: &'static str = "sota-remote";
 const NEW_PACKAGE: &'static str = "/tmp/sota-package";
+const BOOT_BRANCH: &'static str = "/usr/share/sota/branchname";
 
 
 /// Empty container for static `OSTree` functions.
@@ -54,32 +55,34 @@ impl Ostree {
 pub struct OstreePackage {
     #[serde(default)]
     pub ecu_serial: String,
+    pub refName:    String,
     pub commit:     String,
     pub pullUri:    String,
 }
 
 impl OstreePackage {
-    pub fn new(ecu_serial: String, commit: String, treehub: &Url) -> Self {
+    pub fn new(ecu_serial: String, refname: String, commit: String, treehub: &Url) -> Self {
         OstreePackage {
             ecu_serial: ecu_serial,
+            refName:    refname,
             commit:     commit,
             pullUri:    format!("{}", treehub),
         }
     }
 
     /// Convert from `TufMeta` into an `OstreePackage`.
-    pub fn from_meta(mut meta: TufMeta, hash_type: &str, treehub: &Url) -> Result<Self, Error> {
+    pub fn from_meta(mut meta: TufMeta, refname: String, hash_type: &str, treehub: &Url) -> Result<Self, Error> {
         match (meta.hashes.remove(hash_type), meta.custom) {
-            (Some(commit), Some(custom)) => Ok(OstreePackage::new(custom.ecuIdentifier, commit, treehub)),
-            (None, _) => Err(Error::UptaneTargets(format!("missing hash type {}", hash_type))),
-            (_, None) => Err(Error::UptaneTargets("missing custom field".into())),
+            (Some(commit), Some(custom)) => Ok(OstreePackage::new(custom.ecuIdentifier, refname, commit, treehub)),
+            (None, _) => Err(Error::UptaneTargets(format!("{} missing {} hash", refname, hash_type))),
+            (_, None) => Err(Error::UptaneTargets(format!("{} missing custom field", refname))),
         }
     }
 
     /// Convert the current `OstreePackage` into an `EcuVersion`.
     pub fn into_version(self, custom: Option<EcuCustom>) -> EcuVersion {
-        let meta = TufMeta::from("sha256".into(), self.commit.clone());
-        EcuVersion::from(self.ecu_serial, TufImage { filepath: self.commit, fileinfo: meta }, custom)
+        let meta = TufMeta::from("sha256".into(), self.commit);
+        EcuVersion::from(self.ecu_serial, TufImage { filepath: self.refName, fileinfo: meta }, custom)
     }
 
     /// Install this package using the `ostree` command.
@@ -110,15 +113,19 @@ impl OstreePackage {
         if Path::new(NEW_PACKAGE).exists() {
             trace!("getting ostree package from `{}`", NEW_PACKAGE);
             Ok(json::from_reader(BufReader::new(File::open(NEW_PACKAGE)?))?)
+        } else if Path::new(BOOT_BRANCH).exists() {
+            trace!("getting ostree branch from `{}`", BOOT_BRANCH);
+            Ok(Self::get_current(serial, str::from_utf8(&Util::read_file(BOOT_BRANCH)?)?)?)
         } else {
-            Self::get_current(serial)
+            trace!("unknown ostree branch");
+            Ok(Self::get_current(serial, "<unknown>")?)
         }
     }
 
     /// Get the current OSTree package with `ostree admin status`.
-    pub fn get_current(serial: &str) -> Result<OstreePackage, Error> {
+    pub fn get_current(serial: &str, branch: &str) -> Result<OstreePackage, Error> {
         Ostree::run(&["admin", "status"])
-            .and_then(|output| OstreeBranch::parse(serial, str::from_utf8(&output.stdout)?))
+            .and_then(|output| OstreeBranch::parse(serial, branch, str::from_utf8(&output.stdout)?))
             .and_then(|branches| {
                 branches.into_iter()
                     .filter(|branch| branch.current)
@@ -189,7 +196,7 @@ struct OstreeBranch {
 
 impl OstreeBranch {
     /// Parse the output from `ostree admin status`
-    fn parse(ecu_serial: &str, stdout: &str) -> Result<Vec<OstreeBranch>, Error> {
+    fn parse(ecu_serial: &str, branch_name: &str, stdout: &str) -> Result<Vec<OstreeBranch>, Error> {
         stdout.lines()
             .map(str::trim)
             .filter(|line| !line.is_empty())
@@ -202,12 +209,14 @@ impl OstreeBranch {
                     3 if tokens[0].trim() == "*" => Ok((true, tokens[1], tokens[2])),
                     _ => Err(Error::Parse(format!("couldn't parse line: {:?}", lines[0])))
                 }?;
+                let commit = commit.split('.').collect::<Vec<_>>()[0].to_string();
                 Ok(OstreeBranch {
                     current: current,
                     os_name: os_name.into(),
                     package: OstreePackage {
                         ecu_serial: ecu_serial.into(),
-                        commit: commit.split('.').collect::<Vec<_>>()[0].to_string(),
+                        refName: format!("{}-{}", branch_name, commit),
+                        commit:  commit,
                         pullUri: "".into(),
                     },
                 })
@@ -231,12 +240,14 @@ mod tests {
 
     #[test]
     fn parse_branches() {
-        let branches = OstreeBranch::parse("test-serial".into(), OSTREE_ADMIN_STATUS).expect("couldn't parse branches");
+        let branches = OstreeBranch::parse("test-serial".into(), "<branch>", OSTREE_ADMIN_STATUS).expect("couldn't parse branches");
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].current, false);
         assert_eq!(branches[0].os_name, "gnome-ostree");
         assert_eq!(branches[0].package.commit, "67e382b11d213a402a5313e61cbc69dfd5ab93cb07");
+        assert_eq!(branches[0].package.refName, "<branch>-67e382b11d213a402a5313e61cbc69dfd5ab93cb07");
         assert_eq!(branches[1].current, true);
         assert_eq!(branches[1].package.commit, "ce19c41036cc45e49b0cecf6b157523c2105c4de1c");
+        assert_eq!(branches[1].package.refName, "<branch>-ce19c41036cc45e49b0cecf6b157523c2105c4de1c");
     }
 }

--- a/sota-client/src/uptane.rs
+++ b/sota-client/src/uptane.rs
@@ -238,7 +238,7 @@ impl Uptane {
                     images.insert(meta.image_name.clone(), reader);
                     Ok((ecu_serial, hashmap!{ State::Fetch => Payload::ImageMeta(json::to_vec(&meta)?) }))
                 } else {
-                    let pkg = OstreePackage::from_meta(meta.clone(), "sha256", treehub)?;
+                    let pkg = OstreePackage::from_meta(meta.clone(), refname.clone(), "sha256", treehub)?;
                     if ecu_serial == self.primary_ecu { primary_pkg = Some(pkg.clone()); }
                     Ok((ecu_serial, hashmap!{ State::Fetch => Payload::OstreePackage(json::to_vec(&pkg)?) }))
                 }


### PR DESCRIPTION
Aktualizr in production expects the old format, and the refname field can't be dropped until it supports both.